### PR TITLE
Replace curl with wget in luarocks-apline variants

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -41,6 +41,8 @@ RUN set -ex \
         coreutils \
         gnupg \
         unzip \
+        # rundeps
+        wget \
       <% end -%>
   <% end -%>
   && curl -fsSL -o /tmp/lua.tar.gz "<%= archive_url %>" \
@@ -114,7 +116,7 @@ RUN set -ex \
       <% if variant.include?("luarocks") -%>
         ca-certificates \
         coreutils \
-        curl \
+        wget \
         unzip \
       <% end -%>
     && apk del --no-network .lua-builddeps \

--- a/test.sh
+++ b/test.sh
@@ -43,6 +43,16 @@ case "$LUAROCKS" in
         exitcode="1"
         ;;
     esac
+
+    luarocks_search=$(luarocks search --porcelain penlight 1.13.0-1)
+    case "$luarocks_search" in
+      "penlight"*)
+        ;;
+      *)
+        echo "luarocks search command not working as expected"
+        exitcode="1"
+        ;;
+    esac
     ;;
   false)
     if command -v luarocks; then


### PR DESCRIPTION
LuaRocks prefers wget over curl, therefore curl is not used, meanwile Wget provided by BusyBox doesn't support `--timestamping`.

Fixes: https://github.com/GUI/lua-docker/issues/6
See: https://github.com/luarocks/luarocks/blob/5cba4b83f60966045b86ac615df2692c953ebba7/src/luarocks/fs/tools.lua#L19-L20

```
$ ./update
$ docker build --no-cache lua-5.4/luarocks-alpine3.19 --tag lua-5.4-luarocks-check
$ docker run --rm lua-5.4-luarocks-check luarocks search jwt

jwt - Search results for Lua 5.4:
=================================


Rockspecs and source rocks:
---------------------------

api7-lua-resty-jwt
   0.2.5-0 (rockspec) - https://luarocks.org
   0.2.5-0 (src) - https://luarocks.org
   0.2.4-0 (rockspec) - https://luarocks.org
   0.2.4-0 (src) - https://luarocks.org
...
```